### PR TITLE
Fixed bug with missing hour in real time data

### DIFF
--- a/fmiapi/fmirequesthandler.py
+++ b/fmiapi/fmirequesthandler.py
@@ -50,7 +50,15 @@ class FMIRequestHandler:
         while not done:
             request_params = copy.copy(params)
             request_params["starttime"] += datetime.timedelta(hours=max_timespan)*i
-            request_params["endtime"] = request_params["starttime"] + datetime.timedelta(hours=max_timespan-1)
+            request_params["endtime"] = request_params["starttime"] + datetime.timedelta(hours=max_timespan)
+
+            # This additional minute to starting time is to prevent requests from fetching same time twice in
+            # the splitting point. Otherwise previous request's last time will be fetched as first in the next.
+            # FMI's service recognizes minutes as smallest significate time step so seconds or milliseconds could not
+            # be used.
+            if i > 0:
+                request_params["starttime"] += datetime.timedelta(minutes=1)
+
             requests.append(request_params)
 
             if request_params["endtime"] > params["endtime"]:

--- a/tests/fmiapi/test_fmirequesthandler.py
+++ b/tests/fmiapi/test_fmirequesthandler.py
@@ -45,8 +45,8 @@ def describe_fmi_request_handler():
                                    datetime(2011, 1, 23, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone))
 
         expected = [create_daily_query(datetime(2010, 1, 1, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone),
-                                       datetime(2011, 1, 7, hour=23, minute=1, second=0, microsecond=0, tzinfo=timezone)),
-                    create_daily_query(datetime(2011, 1, 8, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone),
+                                       datetime(2011, 1, 8, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone)),
+                    create_daily_query(datetime(2011, 1, 8, hour=0, minute=2, second=0, microsecond=0, tzinfo=timezone),
                                        datetime(2011, 1, 23, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone))]
 
         expected_calls = [call(expected[0]), call(expected[1])]
@@ -66,7 +66,7 @@ def describe_fmi_request_handler():
                                    datetime(2011, 1, 23, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone))
 
         expected = [create_daily_query(datetime(2010, 1, 1, hour=0, minute=1, second=0, microsecond=0, tzinfo=timezone),
-                                       datetime(2011, 1, 7, hour=23, minute=1, second=0, microsecond=0,
+                                       datetime(2011, 1, 8, hour=0, minute=1, second=0, microsecond=0,
                                                 tzinfo=timezone))]
 
         expected_calls = [call(expected[0])]


### PR DESCRIPTION
Previously dataset missed observations from one hour in real time data every 7 days. This was because the request splitter
skipped one hour when dividing the requests. Now the beginning time of the next data request is instead 1 minute forward from previous request's
end time to prevent missing one whole hour worth of data in real time datasets.