### PR TITLE
Fixed missing week bug

### DIFF
--- a/data/supported_queries.json
+++ b/data/supported_queries.json
@@ -6,7 +6,7 @@
       "en": "Weather: real time observations"
     },
     "request": "getFeature",
-    "max_hours_range": 168,
+    "max_hours_range": 167,
     "storedquery_id": "fmi::observations::weather::multipointcoverage",
     "params": [
       "fmisid",
@@ -21,7 +21,7 @@
       "en": "Weather: daily observations"
     },
     "request": "getFeature",
-    "max_hours_range": 8928,
+    "max_hours_range": 8927,
     "storedquery_id": "fmi::observations::weather::daily::multipointcoverage",
     "params": [
       "fmisid",
@@ -35,7 +35,7 @@
       "en": "Weather: monthly averages"
     },
     "request": "getFeature",
-    "max_hours_range": 87600,
+    "max_hours_range": 87599,
     "storedquery_id": "fmi::observations::weather::monthly::multipointcoverage",
     "params": [
       "fmisid",
@@ -50,7 +50,7 @@
       "en": "Solar radiation observations"
     },
     "request": "getFeature",
-    "max_hours_range": 168,
+    "max_hours_range": 167,
     "storedquery_id": "fmi::observations::radiation::multipointcoverage",
     "params": [
       "fmisid",

--- a/fmiapi/fmiapi.py
+++ b/fmiapi/fmiapi.py
@@ -18,8 +18,6 @@ class FMIApi:
     def __init__(self, api_key=''):
         self._api_key = api_key
         self._request_handler = FMIRequestHandler(self._api_key)
-        self._DAILY_REQUEST_MAX_RANGE_HOURS = 8928
-        self._REALTIME_REQUEST_MAX_RANGE_HOURS = 168
         self._PATH_TO_STATIONS_CSV = "data/stations.csv"
         self._PATH_TO_QUERY_METADATA = "data/supported_queries.json"
         self._stations = self._load_station_metadata()

--- a/fmiapi/fmirequesthandler.py
+++ b/fmiapi/fmirequesthandler.py
@@ -32,6 +32,7 @@ class FMIRequestHandler:
                 # Handles case where beginning of a multipart request won't contain data
                 # FIXME: Could be done in a way where after new lowerlimit is found, a new batch of requests is calculated instead of doing
                 # FIXME: bunch of useless requests.
+                print('Exception on request', e)
                 if e.error_code != 400:
                     raise e
                 if progress_callback is not None:

--- a/tests/fmiapi/testdata/expected_data.py
+++ b/tests/fmiapi/testdata/expected_data.py
@@ -84,7 +84,7 @@ EXPECTED_LAMMI_CATALOG_AUGMENTED_METADATA = [
     {**EXPECTED_LAMMI_CATALOG_METADATA[0], **{
         # Augmented attributes from FMIApi"s supported_queries.json
         "id": "weather",
-        "max_hours_range": 168,
+        "max_hours_range": 167,
         "name": {
             "en": "Weather: real time observations",
             "fi": "Sää: reaaliaikahavainnot"
@@ -95,7 +95,7 @@ EXPECTED_LAMMI_CATALOG_AUGMENTED_METADATA = [
     {**EXPECTED_LAMMI_CATALOG_METADATA[1], **{
         # Augmented attributes from FMIApi"s supported_queries.json
         "id": "monthly",
-        "max_hours_range": 87600,
+        "max_hours_range": 87599,
         "name": {
             "en": "Weather: monthly averages",
             "fi": "Sää: kuukausikeskiarvot"
@@ -106,7 +106,7 @@ EXPECTED_LAMMI_CATALOG_AUGMENTED_METADATA = [
     {**EXPECTED_LAMMI_CATALOG_METADATA[2], **{
         # Augmented attributes from FMIApi"s supported_queries.json
         "id": "daily",
-        "max_hours_range": 8928,
+        "max_hours_range": 8927,
         "name": {
             "en": "Weather: daily observations",
             "fi": "Sää: vuorokausihavainnot"


### PR DESCRIPTION
Daylight saving in the end of October broke request splitting by generating too long time interval and therefore failing the request.
Fixed by tweaking the max_hours_range to be one hour shorter than true FMI's limit.